### PR TITLE
Set top-left anchors for Territory elements

### DIFF
--- a/scenes/territory.tscn
+++ b/scenes/territory.tscn
@@ -14,23 +14,29 @@ shape = SubResource("RectangleShape2D_uiw4v")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_direction = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
 metadata/_edit_use_anchors_ = true
 
 [node name="UnitLabel" type="Label" parent="."]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = 100.0
-offset_top = 17.0
-offset_right = 101.0
-offset_bottom = 94.0
+anchors_preset = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4


### PR DESCRIPTION
## Summary
- Anchor ColorRect to (0,0) with zero offsets
- Anchor UnitLabel to (0,0) for script-driven layout

## Testing
- `godot3 --headless --path . -q` *(fails: project created with newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_689d11baf6dc8320ad78824450d1f02a