### PR TITLE
Fix territory click signal not firing in Godot map

### DIFF
--- a/scenes/map.gd
+++ b/scenes/map.gd
@@ -19,12 +19,13 @@ func _ready() -> void:
 
 	var gap: float = 20.0
 
-	for i in range(rows * cols):
-		var territory: Territory = TerritoryScene.instantiate()
-		territory.territory_id = i
-		territory.controller_id = i % 3
-		territory.start_units = 10
-		territory.territory_clicked.connect(_on_territory_clicked)
+        for i in range(rows * cols):
+                var territory: Territory = TerritoryScene.instantiate()
+                territory.territory_id = i
+                territory.controller_id = i % 3
+                territory.start_units = 10
+                territory.allow_clicks = true
+                territory.clicked.connect(_on_territory_clicked)
 
 		var rect: Vector2 = territory.rect_size
 		var col: int = i % cols
@@ -54,9 +55,9 @@ func _ready() -> void:
 		adjacency[i] = neighbors
 
 
-func _on_territory_clicked(territory: Territory) -> void:
-	print("Клик по территории id=", territory.territory_id)
-	map_territory_clicked.emit(territory.territory_id)
+func _on_territory_clicked(id: int) -> void:
+        print("Клик по территории id=", id)
+        map_territory_clicked.emit(id)
 
 
 func get_territory_by_id(id: int) -> Territory:

--- a/scenes/territory.gd
+++ b/scenes/territory.gd
@@ -2,7 +2,8 @@ extends Area2D
 class_name Territory
 
 # ===== Сигналы =====
-signal territory_clicked(territory: Territory)
+# Срабатывает при клике по территории
+signal clicked(id: int)
 signal units_changed(territory: Territory, new_units: int)
 signal controller_changed(territory: Territory, new_controller_id: int)
 
@@ -47,8 +48,7 @@ func _ready() -> void:
 	_apply_rect_size()
 	_units = start_units
 	_update_label()
-	_apply_controller_color()
-	self.input_event.connect(_on_area_input_event)
+        _apply_controller_color()
 
 # ===== Настройка размеров =====
 func _apply_rect_size() -> void:
@@ -111,13 +111,14 @@ func set_controller_color(custom_color: Color) -> void:
 		_color_rect.color = custom_color
 
 # ===== Обработка ввода =====
-func _on_area_input_event(viewport: Viewport, event: InputEvent, shape_idx: int) -> void:
-	if not allow_clicks:
-		return
-	if event is InputEventMouseButton and event.pressed:
-		var mb: InputEventMouseButton = event as InputEventMouseButton
-		if mb.button_index == MOUSE_BUTTON_LEFT:
-			territory_clicked.emit(self)
+func _input_event(viewport: Viewport, event: InputEvent, shape_idx: int) -> void:
+        if not allow_clicks:
+                return
+        if event is InputEventMouseButton and event.pressed:
+                var mb: InputEventMouseButton = event as InputEventMouseButton
+                if mb.button_index == MOUSE_BUTTON_LEFT:
+                        print("Territory clicked id=", territory_id)
+                        clicked.emit(territory_id)
 
 # ===== Рост юнитов =====
 func grow_once() -> void:


### PR DESCRIPTION
## Summary
- add explicit `clicked(id)` signal to `Territory` and emit in `_input_event`
- connect `clicked` signal from each territory in `Map` and forward to GameManager
- ensure territories are pickable and add debug prints for click handling

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689dd79bc0148320a884507cbf660696